### PR TITLE
Backlog ref #3: Fix Coveralls.io badge icon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # C++ Boilerplate Badges
 [![Build Status](https://github.com/TommyChangUMD/cpp-boilerplate/actions/workflows/build_and_coveralls.yml/badge.svg)](https://github.com/TommyChangUMD/cpp-boilerplate/actions/workflows/build_and_coveralls.yml)
 
-[![Coverage Status](https://coveralls.io/repos/github/TommyChangUMD/cpp-boilerplate/badge.png?branch=master)](https://coveralls.io/github/TommyChangUMD/cpp-boilerplate?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/TommyChangUMD/cpp-boilerplate/badge.svg?branch=master)](https://coveralls.io/github/TommyChangUMD/cpp-boilerplate?branch=master)
 
 
 ## Overview


### PR DESCRIPTION
The Coveralls.io badge icon doesn't seem show up when displayed on GitHub page.  Opennig the web browswer in private mode does not seem to help.  This commit reverts back the icon to .svg image (instead of png).