### PR TITLE
Backlog ref #3: Limit GitHub CI workflow event

### DIFF
--- a/.github/workflows/build_and_coveralls.yml
+++ b/.github/workflows/build_and_coveralls.yml
@@ -15,10 +15,10 @@ on:
   push:
     branches: [ "master" ]
 
-  # Triggered whenever the master branch opens and closes a pull request
+  # Triggered whenever a pull request is created on master
   pull_request:
     branches: [ "master" ]
-    types: [opened, closed]
+    types: [opened]
 
   # Allow manual trigger
   workflow_dispatch:


### PR DESCRIPTION
This commit updates the GitHub CI workflow configuration to trigger on opened PR only.  Closing the PR (ie, merge) should not trigger the build again.