### PR TITLE
Backlog ref #4: Simplify CMakeLists.txt and add more source files for…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ if (COVERAGE)
     include(CodeCoverage)
     set(LCOV_REMOVE_EXTRA "'*vendor/*'")
     setup_target_for_coverage(code_coverage test/cpp-test coverage)
-    set(COVERAGE_SRCS app/main.cpp include/lib.hpp)
 
     SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
     SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
+#include "lib.hpp"
 
 void function_not_used()
 {
+  dummy();
   int notUsed = 0;
 }
 


### PR DESCRIPTION
… unit test

This commit modifies CMakeLists.txt to remove the unused "COVERAGE_SRCS" variable.  The unit test driver is also modified to depend on more source files.